### PR TITLE
Fix Ignore paths

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -93,8 +93,8 @@ const fileTypes = {
 	],
 
 	exclusions: [
-		'node_modules/',
-		'.git/'
+		'**/node_modules',
+		'**/.git'
 	]
 }
 
@@ -559,13 +559,10 @@ const startLiveReloadServer = (liveReloadPort, flags) => {
 	}
 
 	const exts = fileTypes.watch.map(type => type.slice(1))
-	const exclusions = fileTypes.exclusions.map(exPath => {
-		return path.join(dir, exPath)
-	})
 
 	return liveReload.createServer({
 		exts,
-		exclusions,
+		exclusions: fileTypes.exclusions,
 		port: liveReloadPort
 	}).watch(path.resolve(dir))
 }


### PR DESCRIPTION
Fixes the issue whereby markserv **only** ignores `node_modules` folders first level deep from the watched directory.

This was happening because the code was building an array of absolute paths by taking the directory-to-be-watched by markserv and appending the exclusions defined at L96.

For example, if a user would run `markserv ./` within the `/home/alice` folder, then the ignore paths would become: `[/home/alice/node_modules/, /home/alice/.git]`. This will obviously ignore any other `node_modules` folder that is at a deeper level within the `/home/alice` folder.

This fix passes the exclusions directly to the `liveReload` server which in turn passes them, unchanged, to the `chockidar` library and ensures that we markdown achieves the expected behavior with regards to ignore path.